### PR TITLE
helpers(prep): central config loader + path rendering; wire exp_setup; prep YAML trimmed

### DIFF
--- a/configs/sequence_fold.yaml
+++ b/configs/sequence_fold.yaml
@@ -1,173 +1,39 @@
-# configs/sequence_fold_full.yaml
+# Minimal prep-only config (consumed by core.config.load_config(mode="prep"))
 
 experiment:
   name: "sequence_fold_full"
   seed: 42
-  profile_default: "full"   # "full" | "debug"
-
-artifacts:
-  roots:
-    experiments: "/mimer/NOBACKUP/groups/snic2022-22-552/filbern/fungal_classification/experiments"
-    pretrained:  "/mimer/NOBACKUP/groups/snic2022-22-552/filbern/fungal_classification/pretrained_models"
-  paths:
-    # ---- used by 01_experiment_prep.py ----
-    prepared_dir:        "{experiments_root}/{experiment_name}/data"
-    logs_dir:            "{experiments_root}/{experiment_name}/logs"
-    prep_log:            "{experiments_root}/{experiment_name}/logs/prep.log"
-    prep_summary_json:   "{experiments_root}/{experiment_name}/data/{prep_summary_filename}"
-
-    # ---- shared helpers for pretrain/finetune (you can use these or compute in code) ----
-    arch_root:             "{experiments_root}/{experiment_name}/{arch_id}/{profile}"
-    pretrain_run_dir:      "{experiments_root}/{experiment_name}/{arch_id}/{profile}/pretrain"
-    pretrain_ckpt_dir:     "{experiments_root}/{experiment_name}/{arch_id}/{profile}/pretrain/checkpoints"
-    finetune_run_dir:      "{experiments_root}/{experiment_name}/{arch_id}/{profile}/folds/fold_{fold:02d}/{task}"
-    finetune_ckpt_dir:     "{experiments_root}/{experiment_name}/{arch_id}/{profile}/folds/fold_{fold:02d}/{task}/checkpoints"
+  union: "standard"   # must match a key under data.inputs
 
 data:
-  experiments_root: "${ARTIFACTS_EXPERIMENTS_ROOT:-/mimer/NOBACKUP/groups/snic2022-22-552/filbern/fungal_classification/experiments}"
-  input_dir: "${UNION_INPUT_DIR:-/mimer/NOBACKUP/groups/snic2022-22-552/filbern/fungal_classification/inputs}"
+  # Absolute paths only (no env indirection)
+  experiments_root: "/mimer/NOBACKUP/groups/snic2022-22-552/filbern/fungal_classification/experiments"
+  input_dir: "/mimer/NOBACKUP/groups/snic2022-22-552/filbern/fungal_classification/blast_filtered"
   filenames:
     prep_summary: "prep_summary.json"
-  # union membership for prep
   inputs:
-    sequence_fold_full: ["blast_union_A", "blast_union_B"]  # csv basenames (without .csv)
+    standard: ["a_original_sh_sequences", "b_recruited_99pct_species", "d_recruited_97pct_sp"]
+    conservative: ["a_original_sh_sequences", "b_recruited_99pct_species", "c_recruited_99pct_sp"]
 
 label_space:
-  levels: ["phylum","class","order","family","genus","species"]
+  levels: ["phylum", "class", "order", "family", "genus", "species"]
 
-prep:  # 01_experiment_prep.py only
+prep:
   uppercase_sequences: true
-  min_species_resolution: 0
+  min_species_resolution: 4
   dedupe:
     scope: "within_species"
-    keep_policy: "highest_resolution"   # or "first"/"last"
-  folds:  # exp1: sequence-level stratified kfold
+    keep_policy: "highest_resolution"
+  folds:
     k: 10
     stratify_by: "species"
     seed: 42
-  folds_species_group:  # exp2: species-group, stratify by genus
+  folds_species_group:
     k: 10
     stratify_by: "genus"
     seed: 42
   debug_subset:
-    enabled: false
-    n_genera: 30
-    min_species_per_genus: 5
-    target_size: 20000
+    n_genera: 5
+    min_species_per_genus: 2
+    target_size: 10000
     seed: 42
-
-preprocessing:  # shared by pretrain + finetune
-  alphabet: ["A","C","G","T"]
-  k: 3
-  max_bases: 1500            # must be divisible by k; optimal_length=max_bases/k; MPE=optimal_length+2
-  truncation: "sliding_window"  # informational; implementation is fixed today
-
-model:  # shared encoder spec; arch_id derived from this + MPE
-  encoder:
-    hidden_size: 512
-    num_hidden_layers: 10
-    num_attention_heads: 8
-    intermediate_size: 2048
-    hidden_dropout_prob: 0.10
-    attention_probs_dropout_prob: 0.10
-
-scheduler_catalog:  # shared shapes; pick by key in each task section
-  tri:
-    base: "step"
-    warmup: {type: "linear", duration: 1}
-    main:   {type: "tri", plateau: 3, decay: 8}
-    floor:  {min_factor: 1.0e-2}
-  cosine:
-    base: "step"
-    warmup: {type: "linear", duration: 1}
-    main:   {type: "cosine", epochs: 10}
-    floor:  {min_factor: 1.0e-2}
-  cosine_restarts:
-    base: "step"
-    warmup: {type: "linear", duration: 1}
-    main:   {type: "cosine_restarts", cycle_epochs: 5, num_cycles: 3, t_mult: 1.0, peak_decay: 0.8}
-    floor:  {min_factor: 1.0e-2}
-
-tasks:
-
-  pretrain:
-    profile: "${PROFILE:-full}"    # runtime default
-    fold_index_for_val: 7          # uses exp1 folds to carve train!=fold, val==fold
-    mlm:
-      masking_pct: 0.15
-      mlm_dropout: 0.10
-      tie_to_embeddings: true
-    dataloader:
-      batch_size: 126
-      num_workers: 4
-      pin_memory: true
-      drop_last_train: true
-      prefetch_factor: 4
-    optimizer:
-      name: "AdamW"
-      learning_rate: 1.8e-4
-      weight_decay: 0.01
-      betas: [0.9, 0.999]
-      eps: 1.0e-8
-    scheduler:
-      kind: "tri"  # key into scheduler_catalog
-    trainer:
-      max_epochs: 600
-      amp: true
-      log_every: 100
-      save_every_epochs: 1
-    promotion:   # where best.pt is copied
-      pretrained_root: "{pretrained_root}/{arch_id}/best.pt"
-
-  finetune:
-    profile: "${PROFILE:-full}"
-    levels: "all"                  # "all" or explicit list like ["species"] or ["genus","species"]
-    fold_scheme: "exp1"            # "exp1" | "exp2"
-    fold_index: 7
-    head:
-      hierarchical_dropout: 0.10
-      bottleneck: 256
-    backbone:
-      path: "/mimer/NOBACKUP/groups/snic2022-22-552/filbern/fungal_classification/pretrained_models/bert_h512_L10_H8_i2048_P502/best.pt"  # null → derive by arch_id
-      strict: true
-    dataloader:
-      batch_size: 128
-      num_workers: 4
-      pin_memory: true
-      sampler: "species_balanced"  # informational; current code constructs this internally
-      drop_last_train: true
-      prefetch_factor: 4
-    optimizer:
-      name: "AdamW"
-      learning_rate: 1.0e-4
-      weight_decay: 0.10
-      betas: [0.9, 0.999]
-      eps: 1.0e-8
-    scheduler:
-      kind: "tri"
-    trainer:
-      max_epochs: 10
-      amp: true
-      log_every: 5
-
-profiles:  # optional profile-specific overrides merged on top of everything above
-  debug:
-    preprocessing:
-      max_bases: 600
-    model:
-      encoder:
-        hidden_size: 64
-        num_hidden_layers: 2
-        num_attention_heads: 2
-        intermediate_size: 256
-    tasks:
-      pretrain:
-        dataloader: {batch_size: 16, num_workers: 0, prefetch_factor: null, drop_last_train: true}
-        optimizer: {learning_rate: 1.8e-4}
-        trainer:   {max_epochs: 2, amp: false, log_every: 20}
-      finetune:
-        backbone:
-          path: "/mimer/NOBACKUP/groups/snic2022-22-552/filbern/fungal_classification/pretrained_models/bert_h64_L2_H2_i256_P202/best_clean.pt"
-          strict: true
-        dataloader: {batch_size: 16, num_workers: 0, prefetch_factor: null, drop_last_train: true}
-        trainer:   {max_epochs: 2, amp: false, log_every: 5}

--- a/src/taxml/core/config.py
+++ b/src/taxml/core/config.py
@@ -1,5 +1,9 @@
+from __future__ import annotations
 from pathlib import Path
-from typing import Dict
+from typing import Any, Dict, Literal
+
+from .io import read_yaml
+from .paths import prep_paths
 
 def build_profile_paths(
     experiments_root: str | Path,
@@ -23,3 +27,77 @@ def build_profile_paths(
         "summary_json": data_dir / "summary.json",
         "logs_dir": logs_dir,
     }
+
+
+Required = Literal["experiment","artifacts","data","label_space","prep"]
+
+def _require(d: Dict, key: str) -> Any:
+    if key not in d:
+        raise KeyError(f"Missing required key: {key}")
+    return d[key]
+
+def load_config(mode: Literal["prep","pretrain","finetune"], config_path: str | Path) -> Dict[str, Any]:
+    if mode != "prep":
+        # stub for future modes
+        raise NotImplementedError(f"load_config(mode={mode!r}) only supports 'prep' right now")
+
+    cfg_raw = read_yaml(Path(config_path))
+
+    # --- validate + extract minimal schema for prep ---
+    exp        = _require(cfg_raw, "experiment")
+    data       = _require(cfg_raw, "data")
+    label_space= _require(cfg_raw, "label_space")
+    prep       = _require(cfg_raw, "prep")
+
+    name   = _require(exp, "name")
+    seed   = _require(exp, "seed")
+    union  = _require(exp, "union")
+
+    # absolute roots (no envs)
+    experiments_root = Path(_require(data, "experiments_root")).expanduser().resolve()
+    input_dir        = Path(_require(data, "input_dir")).expanduser().resolve()
+
+    inputs     = _require(data, "inputs")
+    filenames  = _require(data, "filenames")
+    levels     = _require(label_space, "levels")
+
+    # derive all prep paths centrally
+    paths = prep_paths(experiments_root, name)
+
+    # flatten into a runtime config dict
+    cfg: Dict[str, Any] = {
+        "experiment": {"name": name, "seed": int(seed), "union": str(union)},
+        "data": {
+            "experiments_root": experiments_root,
+            "input_dir": input_dir,
+            "inputs": inputs,
+            "filenames": filenames,
+        },
+        "label_space": {"levels": list(levels)},
+        "prep": {
+            "uppercase_sequences": bool(prep.get("uppercase_sequences", True)),
+            "min_species_resolution": int(prep.get("min_species_resolution", 0)),
+            "dedupe": {
+                "scope": str(_require(prep, "dedupe")["scope"]),
+                "keep_policy": str(_require(prep, "dedupe")["keep_policy"]),
+            },
+            "folds": {
+                "k": int(_require(prep, "folds")["k"]),
+                "stratify_by": str(_require(prep, "folds")["stratify_by"]),
+                "seed": int(_require(prep, "folds")["seed"]),
+            },
+            "folds_species_group": {
+                "k": int(_require(prep, "folds_species_group")["k"]),
+                "stratify_by": str(_require(prep, "folds_species_group")["stratify_by"]),
+                "seed": int(_require(prep, "folds_species_group")["seed"]),
+            },
+            "debug_subset": {
+                "n_genera": int(_require(prep, "debug_subset")["n_genera"]),
+                "min_species_per_genus": int(_require(prep, "debug_subset")["min_species_per_genus"]),
+                "target_size": int(_require(prep, "debug_subset")["target_size"]),
+                "seed": int(_require(prep, "debug_subset")["seed"]),
+            },
+        },
+        "paths": paths,
+    }
+    return cfg

--- a/src/taxml/core/io.py
+++ b/src/taxml/core/io.py
@@ -1,0 +1,25 @@
+# src/taxml/core/io.py
+from __future__ import annotations
+import json, os
+from pathlib import Path
+from typing import Any
+import yaml
+
+def read_yaml(path: Path) -> dict:
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"YAML not found: {p}")
+    with p.open("r") as f:
+        return yaml.safe_load(f) or {}
+
+def write_json(path: Path, obj: Any, *, atomic: bool = True, indent: int = 2) -> None:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if atomic:
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        with tmp.open("w") as f:
+            json.dump(obj, f, indent=indent)
+        os.replace(tmp, path)
+    else:
+        with path.open("w") as f:
+            json.dump(obj, f, indent=indent)

--- a/src/taxml/core/paths.py
+++ b/src/taxml/core/paths.py
@@ -1,0 +1,39 @@
+# src/taxml/core/paths.py
+from __future__ import annotations
+from pathlib import Path
+from typing import Dict
+
+def prep_paths(experiments_root: Path, experiment_name: str) -> Dict:
+    """
+    Return a dict of absolute paths for experiment *prep* artifacts.
+    Creates base/profile directories but does not create output files.
+    """
+    exp_root  = Path(experiments_root).expanduser().resolve() / experiment_name
+    logs_dir  = exp_root / "logs"
+    data_root = exp_root / "data"
+
+    profiles = {p: data_root / p for p in ("full", "debug")}
+
+    def _per_profile(filename: str) -> Dict[str, Path]:
+        return {name: d / filename for name, d in profiles.items()}
+
+    out: Dict = {
+        "exp_root": exp_root,
+        "logs_dir": logs_dir,
+        "prep_log": logs_dir / "prep.log",
+        "data_root": data_root,
+        "profile_dirs": profiles,
+        "prepared_csv": _per_profile("prepared.csv"),
+        "label_space_json": _per_profile("label_space.json"),
+        "fold_masks": {
+            "exp1": _per_profile("fold_masks_exp1.json"),
+            "exp2": _per_profile("fold_masks_exp2.json"),
+        },
+        "prep_summary_json": data_root / "prep_summary.json",
+    }
+
+    # Ensure directories exist
+    for d in [logs_dir, data_root, *profiles.values()]:
+        d.mkdir(parents=True, exist_ok=True)
+
+    return out


### PR DESCRIPTION
## Summary
Prep-first helpers refactor:
- `core.config.load_config('prep')` returning a flat runtime dict.
- `core.paths.prep_paths(...)` centralizes all prep paths (full & debug).
- `core.io.read_yaml` / `write_json` (atomic writes).
- `cli/exp_setup.py` wired to the loader; paths unpacked early and used as variables.
- Overwrite guard with `--yes`.
- YAML trimmed to prep-relevant schema; no env-expansion in loader.

## Notes / Breaking
- `debug_subset.enabled` ignored; we always emit both profiles (empty debug gets a clear summary).
- Paths are absolute, derived centrally.
- Pretrain/finetune adoption will follow in separate issues.

## Manual verification
- Ran `exp_setup` end-to-end on real inputs; produced both profiles.
- Pretrain/finetune run against prepared data (not yet using loader).

Closes #25
Closes #5
Closes #6
Closes #7
